### PR TITLE
Re-wire so postgres binary location can be explicitly configured

### DIFF
--- a/lock.go
+++ b/lock.go
@@ -68,7 +68,7 @@ func (cfg *Config) removeStaleAndTryLock() error {
 
 	// If we had to remove a stale lock, maybe there is a stale Postgres
 	// instance still running, too?
-	if err := shutdownPostgres(cfg.dir); err != nil {
+	if err := shutdownPostgres(cfg, cfg.dir); err != nil {
 		log.Printf("stale postgres cleanup failed: %v", err)
 	}
 

--- a/lock.go
+++ b/lock.go
@@ -27,21 +27,21 @@ import (
 	"syscall"
 )
 
-func lockfn(dir string) string {
-	return filepath.Join(dir, "lock")
+func (cfg *Config) lockfn() string {
+	return filepath.Join(cfg.dir, "lock")
 }
 
-func tryLock(dir string) error {
-	lockfn := lockfn(dir)
+func (cfg *Config) tryLock() error {
+	lockfn := cfg.lockfn()
 	lockf, err := os.OpenFile(lockfn, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0644)
 	if err != nil {
 		if os.IsNotExist(err) {
 			// The parent directory does not exist.
 			// Create the directory and retry.
-			if err := os.MkdirAll(dir, 0755); err != nil {
+			if err := os.MkdirAll(cfg.dir, 0755); err != nil {
 				return err
 			}
-			return tryLock(dir)
+			return cfg.tryLock()
 		}
 		if os.IsExist(err) {
 			return fmt.Errorf("Lock file %s already exists -- did another process race us?", lockfn)
@@ -55,8 +55,8 @@ func tryLock(dir string) error {
 	return lockf.Close()
 }
 
-func removeStaleAndTryLock(dir string) error {
-	lockfn := lockfn(dir)
+func (cfg *Config) removeStaleAndTryLock() error {
+	lockfn := cfg.lockfn()
 	log.Printf("removing stale lockfile %s", lockfn)
 	if err := os.Remove(lockfn); err != nil {
 		if os.IsNotExist(err) {
@@ -68,27 +68,27 @@ func removeStaleAndTryLock(dir string) error {
 
 	// If we had to remove a stale lock, maybe there is a stale Postgres
 	// instance still running, too?
-	if err := shutdownPostgres(dir); err != nil {
+	if err := shutdownPostgres(cfg.dir); err != nil {
 		log.Printf("stale postgres cleanup failed: %v", err)
 	}
 
 	// Remove log.txt and data dir, otherwise starting a new instance will fail
-	if err := os.Remove(filepath.Join(dir, "log.txt")); err != nil {
+	if err := os.Remove(filepath.Join(cfg.dir, "log.txt")); err != nil {
 		log.Printf("stale postgres cleanup failed: %v", err)
 	}
-	if err := os.RemoveAll(filepath.Join(dir, "data")); err != nil {
+	if err := os.RemoveAll(filepath.Join(cfg.dir, "data")); err != nil {
 		log.Printf("stale postgres cleanup failed: %v", err)
 	}
 
-	return tryLock(dir)
+	return cfg.tryLock()
 }
 
-func lock(dir string) error {
-	b, err := os.ReadFile(lockfn(dir))
+func (cfg *Config) lock() error {
+	b, err := os.ReadFile(cfg.lockfn())
 	if err != nil {
 		if os.IsNotExist(err) {
 			// Lock available
-			return tryLock(dir)
+			return cfg.tryLock()
 		}
 		return err
 	}
@@ -100,11 +100,11 @@ func lock(dir string) error {
 	proc, err := os.FindProcess(int(lockPid))
 	if err != nil {
 		// stale lock file (non-unix systems)
-		return removeStaleAndTryLock(dir)
+		return cfg.removeStaleAndTryLock()
 	}
 	if err := proc.Signal(syscall.Signal(0)); err != nil {
 		// stale lock file (unix systems)
-		return removeStaleAndTryLock(dir)
+		return cfg.removeStaleAndTryLock()
 	}
 	return fmt.Errorf("already locked by pid %d", lockPid)
 }

--- a/postgrestest.go
+++ b/postgrestest.go
@@ -117,7 +117,7 @@ func Start(ctx context.Context, opts ...Option) (_ *Server, err error) {
 	} else {
 		// The user specified a directory with known path.
 		// Prevent other processes from using the directory.
-		if err := lock(cfg.dir); err != nil {
+		if err := cfg.lock(); err != nil {
 			return nil, err
 		}
 	}
@@ -320,6 +320,7 @@ func findPostgresBin() {
 	if maxVersion < 0 {
 		return
 	}
+
 	postgresBin.dir = filepath.Join(dir, strconv.Itoa(maxVersion), "bin")
 }
 

--- a/postgrestest.go
+++ b/postgrestest.go
@@ -54,6 +54,7 @@ type Server struct {
 type Config struct {
 	driver string
 	dir    string
+	binDir string
 }
 
 // A Option changes something in Config.
@@ -83,6 +84,17 @@ func WithDir(dir string) Option {
 		switch c := c.(type) {
 		case *Config:
 			c.dir = dir
+		}
+	}
+}
+
+// WithBinDir specifies which directory postgrestest should look for postgres
+// binaries.
+func WithBinDir(dir string) Option {
+	return func(c any) {
+		switch c := c.(type) {
+		case *Config:
+			c.binDir = dir
 		}
 	}
 }
@@ -278,6 +290,12 @@ func (cfg *Config) command(name string, args ...string) (*exec.Cmd, error) {
 	if runtime.GOOS == "windows" {
 		name += ".exe"
 	}
+	// Look in given binDir
+	if cfg.binDir != "" {
+		p := filepath.Join(cfg.binDir, name)
+		return exec.Command(p, args...), nil
+	}
+	// Look in path
 	p, lookErr := exec.LookPath(name)
 	if lookErr == nil {
 		return exec.Command(p, args...), nil

--- a/postgrestest.go
+++ b/postgrestest.go
@@ -121,7 +121,7 @@ func Start(ctx context.Context, opts ...Option) (_ *Server, err error) {
 		}
 	}
 	dataDir := filepath.Join(cfg.dir, "data")
-	err = runCommand("initdb",
+	err = cfg.runCommand("initdb",
 		"--no-sync",
 		"--username="+superuserName,
 		"-D", dataDir)
@@ -147,7 +147,7 @@ func Start(ctx context.Context, opts ...Option) (_ *Server, err error) {
 	// On Windows systems, pg_ctl runs in the foreground (not well-documented) and
 	// drops privileges as needed.
 	logFile := filepath.Join(cfg.dir, "log.txt")
-	proc, err := command("pg_ctl", "start", "--no-wait", "--pgdata="+dataDir, "--log="+logFile)
+	proc, err := cfg.command("pg_ctl", "start", "--no-wait", "--pgdata="+dataDir, "--log="+logFile)
 	if err != nil {
 		return nil, fmt.Errorf("start postgres: %w", err)
 	}
@@ -255,26 +255,26 @@ func (srv *Server) Cleanup() {
 	os.RemoveAll(srv.cfg.dir)
 }
 
-func shutdownPostgres(dir string) error {
+func shutdownPostgres(cfg *Config, dir string) error {
 	// Use Immediate Shutdown mode. We don't care about data corruption.
 	// https://www.postgresql.org/docs/current/server-shutdown.html
 	//
 	// TODO(someday): What happens if this fails?
-	return runCommand("pg_ctl", "stop",
+	return cfg.runCommand("pg_ctl", "stop",
 		"--pgdata="+filepath.Join(dir, "data"),
 		"--mode=immediate",
 		"--wait")
 }
 
 func (srv *Server) stop() {
-	shutdownPostgres(srv.cfg.dir)
+	shutdownPostgres(srv.cfg, srv.cfg.dir)
 	<-srv.exited
 }
 
 // command creates an *exec.Cmd for the given PostgreSQL program. If it it
 // cannot find the program on the PATH, then it searches some well-known
 // PostgreSQL installation paths.
-func command(name string, args ...string) (*exec.Cmd, error) {
+func (cfg *Config) command(name string, args ...string) (*exec.Cmd, error) {
 	if runtime.GOOS == "windows" {
 		name += ".exe"
 	}
@@ -327,8 +327,8 @@ var postgresBin struct {
 	dir  string
 }
 
-func runCommand(name string, args ...string) error {
-	c, err := command(name, args...)
+func (cfg *Config) runCommand(name string, args ...string) error {
+	c, err := cfg.command(name, args...)
 	if err != nil {
 		return fmt.Errorf("%s: %w", name, err)
 	}

--- a/postgrestest.go
+++ b/postgrestest.go
@@ -42,8 +42,7 @@ const superuserName = "postgres"
 
 // A Server represents a running PostgreSQL server.
 type Server struct {
-	dir     string
-	driver  string
+	cfg     *Config
 	baseURL *url.URL
 	conn    *sql.DB
 
@@ -157,8 +156,7 @@ func Start(ctx context.Context, opts ...Option) (_ *Server, err error) {
 	}
 	exited := make(chan struct{})
 	srv := &Server{
-		dir:    cfg.dir,
-		driver: cfg.driver,
+		cfg: &cfg,
 		baseURL: &url.URL{
 			Scheme: "postgres",
 			Host:   "localhost",
@@ -233,7 +231,7 @@ func (srv *Server) NewDatabase(ctx context.Context) (*sql.DB, error) {
 	if err != nil {
 		return nil, err
 	}
-	return sql.Open(srv.driver, dsn)
+	return sql.Open(srv.cfg.driver, dsn)
 }
 
 // CreateDatabase creates a new database on the server and returns its
@@ -254,7 +252,7 @@ func (srv *Server) Cleanup() {
 		srv.conn.Close()
 	}
 	srv.stop()
-	os.RemoveAll(srv.dir)
+	os.RemoveAll(srv.cfg.dir)
 }
 
 func shutdownPostgres(dir string) error {
@@ -269,7 +267,7 @@ func shutdownPostgres(dir string) error {
 }
 
 func (srv *Server) stop() {
-	shutdownPostgres(srv.dir)
+	shutdownPostgres(srv.cfg.dir)
 	<-srv.exited
 }
 


### PR DESCRIPTION
I use this within Bazel builds (https://bazel.build), where I cannot place the required binaries in the expected location(s).

I had to do quite a bit of re-work in the locking and servers to pass the given configurations to the needed places. It's not the prettiest way of structuring it, but overall I think it has turned out OK.