### PR TITLE
Expose TemplateDatabase to allow simplifying new database setup

### DIFF
--- a/postgrestest.go
+++ b/postgrestest.go
@@ -212,6 +212,13 @@ func (srv *Server) DefaultDatabase() string {
 	return srv.dsn("postgres")
 }
 
+// TemplateDatabase returns the data source name of the "template1" database
+// used to create later databases.  You can use this to apply migrations or
+// even fixtures once for the life of a server.
+func (srv *Server) TemplateDatabase() string {
+	return srv.dsn("template1")
+}
+
 func dsnString(u *url.URL) string {
 	dsn := u.String()
 	// We need to set a non-empty Host, otherwise the / separating hostname and

--- a/postgrestest_test.go
+++ b/postgrestest_test.go
@@ -87,6 +87,42 @@ func TestNewDatabase(t *testing.T) {
 	}
 }
 
+func TestTemplateDatabase(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), singleTestTime)
+	defer cancel()
+
+	srv, err := Start(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(srv.Cleanup)
+
+	const createTableStmt = `CREATE TABLE foo (id SERIAL PRIMARY KEY);`
+
+	tmpDb, err := sql.Open("postgres", srv.TemplateDatabase())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer tmpDb.Close()
+
+	_, err = tmpDb.ExecContext(ctx, createTableStmt)
+	if err != nil {
+		t.Fatal("CREATE TABLE in template database: ", err)
+	}
+	tmpDb.Close()
+
+	db1, err := srv.NewDatabase(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db1.Close()
+
+	_, err = db1.ExecContext(ctx, `SELECT 1 FROM "foo"`)
+	if err != nil {
+		t.Fatal("template table not copied and readable: ", err)
+	}
+}
+
 func BenchmarkStart(b *testing.B) {
 	ctx := context.Background()
 	for i := 0; i < b.N; i++ {


### PR DESCRIPTION
Hi! I know this is a "feature", but it's very simple:  it makes it easier to get at the `template1` database in your test server, so you can migrate or add fixtures to that, and later new databases on that server instance copy from template1 implicitly.  That saves on the repeat migrations if the caller is doing a db per test, and it's a lot simpler than adding a system of _arbitrary_ templates.  If someone really needs more than one template, launch another server.

Right now you _can_ get a DSN to template1 on your instance but it's by parsing and changing (*Server).DefaultDatabase(), which is awkward.  I have some of my own code doing this and wanted to improve upstream.